### PR TITLE
Reusing the "forum search" code for searching books

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+Search Book block for Moodle (http://moodle.org/) - Copyright (C) 2009 onwards Eloy Lafuente (stronk7) http://stronk7.com
+
+Provides a block that provides a search against all the Book activities in one course.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details: http://www.gnu.org/copyleft/gpl.html
+
+Created by:
+
+* Eloy Lafuente (stronk7) http://stronk7.com
+
+

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2013083100; // The current block version (Date: YYYYMMDDXX)
+$plugin->version   = 2016011600; // The current block version (Date: YYYYMMDDXX)
 $plugin->requires  = 2012062500; // Requires this Moodle version (v2.3.0)
 $plugin->component = 'block_search_books';
 


### PR DESCRIPTION
G'day,

I've updated the Book search block to use the same approach as the Forum search block to translating the search string into SQL.

This removes (I believe) problems with potential SQL injection attacks and enhances support for using search modifiers (" - +).

It does slightly change the performance of the search.  The prior approach would "find a chapter" only if either the title or the content contained the entire search string.  This new approach (as per the forum search) will "find a chapter" as long as the entire search string appears in some combination of the title and the content.

David.
